### PR TITLE
Refactors to support masterless puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Overview
 
 This is a merge of two other layers:
 
-battlemidget/juju-layer-node
+juju-solutions/layer-puppet (idea(s)shamelessly taken from battlemidget/juju-layer-node)
 
 and
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 Overview
 --------
 
-This layer provides the capibility to install, configure, and manage puppet-agent
-across one or more machines. 
+This is a merge of two other layers:
+
+battlemidget/juju-layer-node
+
+and
+
+https://github.com/jamesbeedy/layer-puppet-agent
+
+## states emitted
+
+puppet.available - This state is emitted once Puppet packages are installed. Rely on this state to gate a puppet apply operation.
+
+puppet-agent.available - This state is emitted once Puppet is also configured (puppet.conf)
+
+In summary, puppet.available is for masterless functionality, 
+
+puppet-agent.available for puppet daemon and master.
 
 This layer currently only supports ubuntu releases trusty and precise.
 
 # Contact Information
 
-James Beedy <jamesbeedy@gmail.com>
+James Beedy <jamesbeedy@gmail.com> / bigdata-dev
 
 ## Puppetlabs Puppet-agent
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   puppet-version:
     type: int
-    default: 4
+    default: 3 
     description: |
       Puppet version choices are `3` or `4`.
   pin-puppet:
@@ -19,7 +19,7 @@ options:
       Puppet environment.
   puppet-server:
     type: string
-    default: puppetmaster.test.test
+    default: ''
     description: |
       Puppetmaster fqdn.
   ca-server:

--- a/lib/charms/layer/puppet.py
+++ b/lib/charms/layer/puppet.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3
+# Copyright (c) 2016, James Beedy <jamesbeedy@gmail.com>
+
+import os
+from subprocess import call
+
+from charmhelpers.core.templating import render
+from charmhelpers.core import hookenv
+from charmhelpers.core.host import lsb_release
+from charmhelpers.fetch import (
+    apt_install,
+    apt_update,
+    apt_hold,
+    apt_purge,
+    apt_unhold,
+)
+from charmhelpers.fetch.archiveurl import (
+    ArchiveUrlFetchHandler
+)
+
+config = hookenv.config()
+
+
+class PuppetConfigs:
+    def __init__(self):
+        self.version = config['puppet-version']
+        self.puppet_base_url = 'https://apt.puppetlabs.com'
+        self.puppet_conf = 'puppet.conf'
+        self.auto_start = ('yes','no')
+        self.ensure_running = 'false'
+        self.ubuntu_release = lsb_release()['DISTRIB_CODENAME']
+        self.puppet_ssl_dir = '/var/lib/puppet/ssl/'
+        self.puppet_pkg_vers = ''
+
+        if config['puppet-version'] == 4:
+            self.puppet_pkgs = ['puppet-agent']
+            self.puppet_purge = ['puppet','puppet-common']
+            if config['pin-puppet']:
+                self.puppet_pkg_vers = \
+                    [('puppet-agent=%s' % config['pin-puppet'])]
+            else:
+                self.puppet_pkg_vers = self.puppet_pkgs
+
+            self.puppet_deb = 'puppetlabs-release-pc1-%s.deb' % \
+                              self.ubuntu_release
+            self.puppet_exe = '/opt/puppetlabs/bin/puppet'
+            self.puppet_conf_dir = '/etc/puppetlabs/puppet'
+            if config['auto-start']:
+                self.ensure_running = 'true'
+            self.enable_puppet_cmd = \
+                ('%s resource service puppet ensure=running '
+                 'enable=%s' % (self.puppet_exe, self.ensure_running))
+        elif config['puppet-version'] == 3:
+            self.puppet_pkgs = ['puppet', 'puppet-common']
+            self.puppet_purge = ['puppet-agent']
+            if config['pin-puppet']:
+                self.puppet_pkg_vers = \
+                    [('puppet=%s' % config['pin-puppet']),
+                    ('puppet-common=%s' % config['pin-puppet'])]
+            else:
+                self.puppet_pkg_vers = self.puppet_pkgs
+            self.puppet_deb = 'puppetlabs-release-%s.deb' % \
+                self.ubuntu_release
+            self.puppet_exe = '/usr/bin/puppet'
+            self.puppet_conf_dir = '/etc/puppet'
+            if config['auto-start']:
+                self.auto_start = ('no','yes')
+            self.enable_puppet_cmd = \
+                ('sed -i /etc/default/puppet '
+                 '-e s/START=%s/START=%s/' % self.auto_start)
+        else:
+            hookenv.log('Only puppet versions 3 and 4 suported')
+
+        self.puppet_conf_ctxt = {
+            'environment': config['environment'],
+            'puppet_server': config['puppet-server']
+        }
+        if config['ca-server']:
+            self.puppet_conf_ctxt['ca_server'] = config['ca-server']
+
+
+    def render_puppet_conf(self):
+        ''' Render puppet.conf
+        '''
+        if os.path.exists(self.puppet_conf_path()):
+            os.remove(self.puppet_conf_path())
+        render(source=self.puppet_conf,
+               target=self.puppet_conf_path(),
+               owner='root',
+               perms=0o644,
+               context=self.puppet_conf_ctxt)
+
+
+    def puppet_conf_path(self):
+        '''Return fully qualified path to puppet.conf
+        '''
+        puppet_conf_path = '%s/%s' % (self.puppet_conf_dir, self.puppet_conf)
+        return puppet_conf_path
+
+
+    def puppet_deb_url(self):
+        '''Return fully qualified puppet deb url
+        '''
+        puppet_deb_url = '%s/%s' % (self.puppet_base_url, self.puppet_deb)
+        return puppet_deb_url
+
+
+    def puppet_deb_temp(self):
+        '''Return fully qualified path to downloaded deb
+        '''
+        puppet_deb_temp = os.path.join('/tmp', self.puppet_deb)
+        return puppet_deb_temp
+
+
+    def puppet_running(self):
+    
+        '''Enable or disable puppet auto-start
+        '''
+        call(self.enable_puppet_cmd.split(), shell=False)
+
+
+class Puppet(object):
+    def puppet_active(self):
+        if config['auto-start']:
+            hookenv.status_set('active', 
+                               'Puppet-agent running')
+        else:
+            hookenv.status_set('active', 
+                               'Puppet-agent installed, but not running')
+    
+    
+    def fetch_install_puppet_deb(puppet):
+        '''Fetch and install the puppet deb
+        '''
+        hookenv.status_set('maintenance', 
+                           'Configuring Puppetlabs apt sources')
+        aufh = ArchiveUrlFetchHandler()
+        aufh.download(puppet.puppet_deb_url(), puppet.puppet_deb_temp())
+        dpkg_puppet_deb = 'dpkg -i %s' % puppet.puppet_deb_temp()
+        call(dpkg_puppet_deb.split(), shell=False)
+        apt_update()
+    
+        # Clean up
+        rm_trusty_puppet_deb = 'rm %s' % puppet.puppet_deb_temp()
+        call(rm_trusty_puppet_deb.split(), shell=False)
+        Puppet.puppet_active()
+    
+    
+    def install_puppet(puppet):
+    
+        '''Install puppet
+        '''
+        hookenv.status_set('maintenance', 
+                           'Installing puppet agent')
+        Puppet.fetch_install_puppet_deb(puppet)
+        apt_install(puppet.puppet_pkg_vers)
+        apt_hold(puppet.puppet_pkgs)
+    
+    
+    def configure_puppet(puppet):
+    
+        '''Configure puppet
+        '''
+        hookenv.status_set('maintenance', 
+                           'Configuring puppet agent')
+        puppet.render_puppet_conf()
+        puppet.puppet_running()
+        Puppet.puppet_active()
+    

--- a/lib/charms/layer/puppet.py
+++ b/lib/charms/layer/puppet.py
@@ -11,8 +11,6 @@ from charmhelpers.fetch import (
     apt_install,
     apt_update,
     apt_hold,
-    apt_purge,
-    apt_unhold,
 )
 from charmhelpers.fetch.archiveurl import (
     ArchiveUrlFetchHandler
@@ -119,7 +117,8 @@ class PuppetConfigs:
         call(self.enable_puppet_cmd.split(), shell=False)
 
 
-class Puppet(object):
+#class Puppet(object):
+
     def puppet_active(self):
         if config['auto-start']:
             hookenv.status_set('active', 
@@ -129,41 +128,41 @@ class Puppet(object):
                                'Puppet-agent installed, but not running')
     
     
-    def fetch_install_puppet_deb(puppet):
+    def fetch_install_puppet_deb(self, puppet):
         '''Fetch and install the puppet deb
         '''
         hookenv.status_set('maintenance', 
                            'Configuring Puppetlabs apt sources')
         aufh = ArchiveUrlFetchHandler()
-        aufh.download(puppet.puppet_deb_url(), puppet.puppet_deb_temp())
-        dpkg_puppet_deb = 'dpkg -i %s' % puppet.puppet_deb_temp()
+        aufh.download(self.puppet_deb_url(), self.puppet_deb_temp())
+        dpkg_puppet_deb = 'dpkg -i %s' % self.puppet_deb_temp()
         call(dpkg_puppet_deb.split(), shell=False)
         apt_update()
     
         # Clean up
-        rm_trusty_puppet_deb = 'rm %s' % puppet.puppet_deb_temp()
+        rm_trusty_puppet_deb = 'rm %s' % self.puppet_deb_temp()
         call(rm_trusty_puppet_deb.split(), shell=False)
-        Puppet.puppet_active()
+        self.puppet_active()
     
     
-    def install_puppet(puppet):
+    def install_puppet(self):
     
         '''Install puppet
         '''
         hookenv.status_set('maintenance', 
                            'Installing puppet agent')
-        Puppet.fetch_install_puppet_deb(puppet)
-        apt_install(puppet.puppet_pkg_vers)
-        apt_hold(puppet.puppet_pkgs)
+        self.fetch_install_puppet_deb(self)
+        apt_install(self.puppet_pkg_vers)
+        apt_hold(self.puppet_pkgs)
     
     
-    def configure_puppet(puppet):
+    def configure_puppet(self):
     
         '''Configure puppet
         '''
         hookenv.status_set('maintenance', 
                            'Configuring puppet agent')
-        puppet.render_puppet_conf()
-        puppet.puppet_running()
-        Puppet.puppet_active()
+        self.render_puppet_conf()
+        self.puppet_running()
+        self.puppet_active()
     

--- a/reactive/puppet_agent.py
+++ b/reactive/puppet_agent.py
@@ -2,15 +2,11 @@
 # Copyright (c) 2016, James Beedy <jamesbeedy@gmail.com>
 
 import os
-import sys
 import shutil
-from subprocess import call
 
 from charms.reactive import when, when_not, set_state
 
-from charmhelpers.core.templating import render
 from charmhelpers.core import hookenv
-from charmhelpers.core.host import lsb_release
 from charmhelpers.fetch import (
     apt_install,
     apt_update,
@@ -22,145 +18,8 @@ from charmhelpers.fetch.archiveurl import (
     ArchiveUrlFetchHandler
 )
 
+from charms.layer.puppet import PuppetConfigs, Puppet
 config = hookenv.config()
-
-
-class PuppetConfigs:
-    def __init__(self):
-        self.version = config['puppet-version']
-        self.puppet_base_url = 'https://apt.puppetlabs.com'
-        self.puppet_conf = 'puppet.conf'
-        self.auto_start = ('yes','no')
-        self.ensure_running = 'false'
-        self.ubuntu_release = lsb_release()['DISTRIB_CODENAME']
-        self.puppet_ssl_dir = '/var/lib/puppet/ssl/'
-        self.puppet_pkg_vers = ''
-
-        if config['puppet-version'] == 4:
-            self.puppet_pkgs = ['puppet-agent']
-            self.puppet_purge = ['puppet','puppet-common']
-            if config['pin-puppet']:
-                self.puppet_pkg_vers = \
-                    [('puppet-agent=%s' % config['pin-puppet'])]
-            else:
-                self.puppet_pkg_vers = self.puppet_pkgs
-
-            self.puppet_deb = 'puppetlabs-release-pc1-%s.deb' % \
-                              self.ubuntu_release
-            self.puppet_exe = '/opt/puppetlabs/bin/puppet'
-            self.puppet_conf_dir = '/etc/puppetlabs/puppet'
-            if config['auto-start']:
-                self.ensure_running = 'true'
-            self.enable_puppet_cmd = \
-                ('%s resource service puppet ensure=running '
-                 'enable=%s' % (self.puppet_exe, self.ensure_running))
-        elif config['puppet-version'] == 3:
-            self.puppet_pkgs = ['puppet', 'puppet-common']
-            self.puppet_purge = ['puppet-agent']
-            if config['pin-puppet']:
-                self.puppet_pkg_vers = \
-                    [('puppet=%s' % config['pin-puppet']),
-                    ('puppet-common=%s' % config['pin-puppet'])]
-            else:
-                self.puppet_pkg_vers = self.puppet_pkgs
-            self.puppet_deb = 'puppetlabs-release-%s.deb' % \
-                self.ubuntu_release
-            self.puppet_exe = '/usr/bin/puppet'
-            self.puppet_conf_dir = '/etc/puppet'
-            if config['auto-start']:
-                self.auto_start = ('no','yes')
-            self.enable_puppet_cmd = \
-                ('sed -i /etc/default/puppet '
-                 '-e s/START=%s/START=%s/' % self.auto_start)
-        else:
-            hookenv.log('Only puppet versions 3 and 4 suported')
-
-        self.puppet_conf_ctxt = {
-            'environment': config['environment'],
-            'puppet_server': config['puppet-server']
-        }
-        if config['ca-server']:
-            self.puppet_conf_ctxt['ca_server'] = config['ca-server']
-
-
-    def render_puppet_conf(self):
-        ''' Render puppet.conf
-        '''
-        if os.path.exists(self.puppet_conf_path()):
-            os.remove(self.puppet_conf_path())
-        render(source=self.puppet_conf,
-               target=self.puppet_conf_path(),
-               owner='root',
-               perms=0o644,
-               context=self.puppet_conf_ctxt)
-
-
-    def puppet_conf_path(self):
-        '''Return fully qualified path to puppet.conf
-        '''
-        puppet_conf_path = '%s/%s' % (self.puppet_conf_dir, self.puppet_conf)
-        return puppet_conf_path
-
-
-    def puppet_deb_url(self):
-        '''Return fully qualified puppet deb url
-        '''
-        puppet_deb_url = '%s/%s' % (self.puppet_base_url, self.puppet_deb)
-        return puppet_deb_url
-
-
-    def puppet_deb_temp(self):
-        '''Return fully qualified path to downloaded deb
-        '''
-        puppet_deb_temp = os.path.join('/tmp', self.puppet_deb)
-        return puppet_deb_temp
-
-
-    def puppet_running(self):
-    
-        '''Enable or disable puppet auto-start
-        '''
-        call(self.enable_puppet_cmd.split(), shell=False)
-
-
-def _puppet_active():
-    if config['auto-start']:
-        hookenv.status_set('active', 
-                           'Puppet-agent running')
-    else:
-        hookenv.status_set('active', 
-                           'Puppet-agent installed, but not running')
-
-
-def _fetch_install_puppet_deb(puppet):
-    '''Fetch and install the puppet deb
-    '''
-    hookenv.status_set('maintenance', 
-                       'Configuring Puppetlabs apt sources')
-    aufh = ArchiveUrlFetchHandler()
-    aufh.download(puppet.puppet_deb_url(), puppet.puppet_deb_temp())
-    dpkg_puppet_deb = 'dpkg -i %s' % puppet.puppet_deb_temp()
-    call(dpkg_puppet_deb.split(), shell=False)
-    apt_update()
-
-    # Clean up
-    rm_trusty_puppet_deb = 'rm %s' % puppet.puppet_deb_temp()
-    call(rm_trusty_puppet_deb.split(), shell=False)
-    _puppet_active()
-
-
-def _install_puppet(puppet):
-
-    '''Install puppet
-    '''
-    hookenv.status_set('maintenance', 
-                       'Installing puppet agent')
-    _fetch_install_puppet_deb(puppet)
-    apt_install(puppet.puppet_pkg_vers)
-    apt_hold(puppet.puppet_pkgs)
-    puppet.render_puppet_conf()
-    puppet.puppet_running()
-    _puppet_active()
 
 
 @when_not('puppet-agent.installed')
@@ -174,12 +33,47 @@ def install_puppet_agent():
                        'Installing puppet agent')
     hookenv.status_set('maintenance', 
                        'Configuring Puppetlabs apt sources')
-    _install_puppet(p) 
+    Puppet.install_puppet(p) 
 
     set_state('puppet-agent.installed')
 
 
-@when('config.changed.puppet-server')
+@when('config.set.puppet-server')
+@when_not('puppet-agent.configured')
+def configure_puppet_agent():
+    
+    '''Since the server is set we render 
+    the puppet config files and ensure puppet service running
+    '''
+    p = PuppetConfigs()
+    Puppet.configure_puppet(p)
+
+    set_state('puppet-agent.configured')
+
+
+@when('puppet-agent.installed')
+@when_not('puppet.available')
+def puppet_masterless_ready():
+    
+    '''
+    Set the `puppet.available` state so that other layers can
+    gate puppet operations for masterless puppet state (unconfigured)
+    '''
+    set_state('puppet.available')
+
+
+@when('puppet-agent.installed', 'puppet-agent.configured')
+@when_not('puppet-agent.available')
+def puppet_agent_ready():
+
+    '''
+    Set the `puppet.masterfull.available` state to indicate puppet agent
+    is installed, configured and started in master-client state.
+    '''
+    set_state('puppet-agent.available')
+
+
+@when('config.changed.puppet-server', 'config.set.puppet-server')
 def puppet_server_config_changed():
 
     '''React to puppet-server changed
@@ -189,7 +83,7 @@ def puppet_server_config_changed():
         if os.path.isdir(p.puppet_ssl_dir):
             shutil.rmtree(p.puppet_ssl_dir)
     p.render_puppet_conf()
-    _puppet_active()
+    Puppet.puppet_active()
 
 
 @when('config.changed.puppet-version')
@@ -204,7 +98,7 @@ def puppet_version_config_changed():
     if config.previous('puppet-version') != config['puppet-version']:
         apt_unhold(p.puppet_purge)
         apt_purge(p.puppet_purge)
-        _install_puppet(p)
+        Puppet.install_puppet(p)
 
 
 @when('config.changed.pin-puppet')
@@ -219,10 +113,10 @@ def puppet_version_config_changed():
     if config.previous('pin-puppet') != config['pin-puppet']:
         apt_unhold(p.puppet_purge)
         apt_purge(p.puppet_purge)
-        _install_puppet(p)
+        Puppet.install_puppet(p)
 
 
-@when('config.changed.auto-start')
+@when('config.changed.auto-start', 'config.set.puppet-server')
 def puppet_auto_start_config_changed():
 
     '''React to auto-start changed
@@ -231,10 +125,10 @@ def puppet_auto_start_config_changed():
     hookenv.status_set('maintenance',
                        'Configuring auto-start')
     p.puppet_running()
-    _puppet_active()
+    Puppet.puppet_active()
 
 
-@when('config.changed.environment')
+@when('config.changed.environment', 'config.set.puppet-server')
 def puppet_environment_config_changed():
 
     '''React to config-changed
@@ -244,10 +138,10 @@ def puppet_environment_config_changed():
                        'Configuring new puppet env %s' % \
                        config['environment'])
     p.render_puppet_conf()
-    _puppet_active()
+    Puppet.puppet_active()
 
 
-@when('config.changed.ca-server')
+@when('config.changed.ca-server', 'config.set.puppet-server')
 def puppet_ca_server_config_changed():
 
     '''React to config-changed
@@ -263,4 +157,4 @@ def puppet_ca_server_config_changed():
     if os.path.isdir(p.puppet_ssl_dir):
         shutil.rmtree(p.puppet_ssl_dir)
     p.render_puppet_conf()
-    _puppet_active()
+    Puppet.puppet_active()

--- a/reactive/puppet_agent.py
+++ b/reactive/puppet_agent.py
@@ -18,7 +18,7 @@ from charmhelpers.fetch.archiveurl import (
     ArchiveUrlFetchHandler
 )
 
-from charms.layer.puppet import PuppetConfigs, Puppet
+from charms.layer.puppet import PuppetConfigs
 config = hookenv.config()
 
 
@@ -33,7 +33,7 @@ def install_puppet_agent():
                        'Installing puppet agent')
     hookenv.status_set('maintenance', 
                        'Configuring Puppetlabs apt sources')
-    Puppet.install_puppet(p) 
+    PuppetConfigs.install_puppet(p) 
 
     set_state('puppet-agent.installed')
 
@@ -46,7 +46,7 @@ def configure_puppet_agent():
     the puppet config files and ensure puppet service running
     '''
     p = PuppetConfigs()
-    Puppet.configure_puppet(p)
+    PuppetConfigs.configure_puppet(p)
 
     set_state('puppet-agent.configured')
 
@@ -83,7 +83,7 @@ def puppet_server_config_changed():
         if os.path.isdir(p.puppet_ssl_dir):
             shutil.rmtree(p.puppet_ssl_dir)
     p.render_puppet_conf()
-    Puppet.puppet_active()
+    PuppetConfigs.puppet_active(p)
 
 
 @when('config.changed.puppet-version')
@@ -98,7 +98,7 @@ def puppet_version_config_changed():
     if config.previous('puppet-version') != config['puppet-version']:
         apt_unhold(p.puppet_purge)
         apt_purge(p.puppet_purge)
-        Puppet.install_puppet(p)
+        PuppetConfigs.install_puppet(p)
 
 
 @when('config.changed.pin-puppet')
@@ -113,7 +113,7 @@ def puppet_version_config_changed():
     if config.previous('pin-puppet') != config['pin-puppet']:
         apt_unhold(p.puppet_purge)
         apt_purge(p.puppet_purge)
-        Puppet.install_puppet(p)
+        PuppetConfigs.install_puppet(p)
 
 
 @when('config.changed.auto-start', 'config.set.puppet-server')
@@ -125,7 +125,7 @@ def puppet_auto_start_config_changed():
     hookenv.status_set('maintenance',
                        'Configuring auto-start')
     p.puppet_running()
-    Puppet.puppet_active()
+    PuppetConfigs.puppet_active(p)
 
 
 @when('config.changed.environment', 'config.set.puppet-server')
@@ -138,7 +138,7 @@ def puppet_environment_config_changed():
                        'Configuring new puppet env %s' % \
                        config['environment'])
     p.render_puppet_conf()
-    Puppet.puppet_active()
+    PuppetConfigs.puppet_active(p)
 
 
 @when('config.changed.ca-server', 'config.set.puppet-server')
@@ -157,4 +157,4 @@ def puppet_ca_server_config_changed():
     if os.path.isdir(p.puppet_ssl_dir):
         shutil.rmtree(p.puppet_ssl_dir)
     p.render_puppet_conf()
-    Puppet.puppet_active()
+    PuppetConfigs.puppet_active(p)


### PR DESCRIPTION
For the Bigtop charms, we also created  [a Puppet layer](https://github.com/juju-solutions/layer-puppet), geared  toward masterless usage.  It makes far more sense to add that functionality to this layer, rather than having to separate layers.

This also includes some refactors to fix lint errors we noticed, and to follow some conventions that we recommend for layers (e.g., putting layer libs under the `charms.layer.<layer_name>` namespace).