### PR TITLE
make puppet-version a layer option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,11 @@
 options:
-  puppet-version:
-    type: int
-    default: 4 
-    description: |
-      Puppet version choices are `3` or `4`.
   pin-puppet:
     type: string
     default: ''
     description: |
       This will override the system default for the
-      general version of puppet specified by the 
-      puppet-version config parameter.
+      general version of puppet specified by the
+      puppet-version layer option.
   environment:
     type: string
     default: production

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,2 +1,10 @@
-includes: ['layer:basic', 'layer:apt']  # if you use any interfaces, add them here
 repo: https://github.com/jamesbeedy/layer-puppet-agent.git
+includes:
+  - 'layer:basic'
+  - 'layer:apt'
+defines:
+  puppet-version:
+    type: string
+    default: '4'
+    description: |
+      Puppet version choices are `3` or `4`.

--- a/lib/charms/layer/puppet.py
+++ b/lib/charms/layer/puppet.py
@@ -4,6 +4,7 @@
 import os
 from subprocess import call
 
+from charms import layer
 from charmhelpers.core.templating import render
 from charmhelpers.core import hookenv
 from charmhelpers.core.host import lsb_release
@@ -16,7 +17,8 @@ config = hookenv.config()
 
 class PuppetConfigs:
     def __init__(self):
-        self.version = config['puppet-version']
+        self.options = layer.options('puppet-agent')
+        self.version = self.options.get('puppet-version')
         self.puppet_base_url = 'http://apt.puppetlabs.com'
         self.puppet_conf = 'puppet.conf'
         self.auto_start = ('yes', 'no')
@@ -26,7 +28,7 @@ class PuppetConfigs:
         self.puppet_pkg_vers = ''
         self.puppet_gpg_key = config['puppet-gpg-key']
 
-        if config['puppet-version'] == 4:
+        if self.version == '4':
             self.puppet_pkgs = ['puppet-agent']
             self.puppet_purge_pkgs = ['puppet', 'puppet-common']
             if config['pin-puppet']:
@@ -44,7 +46,7 @@ class PuppetConfigs:
             self.enable_puppet_cmd = \
                 ('%s resource service puppet ensure=running '
                  'enable=%s' % (self.puppet_exe, self.ensure_running))
-        elif config['puppet-version'] == 3:
+        elif self.version == '3':
             self.puppet_pkgs = ['puppet', 'puppet-common']
             self.puppet_purge_pkgs = ['puppet-agent']
             if config['pin-puppet']:


### PR DESCRIPTION
Puppet 3 vs 4 is a massive upgrade. It would be easy to break lots of software
(e.g. Bigtop) if a user inadvertently changed the major puppet version of a
Bigtop charm post deployment. Move the puppet version to a layer option, which
is only mutable at deploy-time.

There is still the 'pin-puppet' config option if users really want to override
our default.