### PR TITLE
move pkg installation to install func; setup repo when masterless

### DIFF
--- a/lib/charms/layer/puppet.py
+++ b/lib/charms/layer/puppet.py
@@ -121,8 +121,6 @@ class PuppetConfigs:
         charms.apt.add_source(self.puppet_apt_src, key=self.puppet_gpg_key)
         # Apt update to pick up the sources
         charms.apt.update()
-        # Queue the installation of appropriate puppet pkgs
-        charms.apt.queue_install(self.puppet_pkg_vers)
 
     def install_puppet(self):
         '''Install puppet
@@ -130,6 +128,8 @@ class PuppetConfigs:
         hookenv.status_set('maintenance',
                            'Installing puppet agent')
         self.install_puppet_apt_src()
+        # Queue the installation of appropriate puppet pkgs
+        charms.apt.queue_install(self.puppet_pkg_vers)
         charms.apt.install_queued()
 
     def configure_puppet(self):

--- a/reactive/puppet_agent.py
+++ b/reactive/puppet_agent.py
@@ -21,7 +21,6 @@ config = hookenv.config()
 @when('config.set.puppet-server')
 @when_not('puppet-agent.installed')
 def install_puppet_agent():
-
     '''Install puppet agent
     '''
     p = PuppetConfigs()
@@ -40,10 +39,15 @@ def masterless_puppet():
     Set the `puppet.available` state so that other layers can
     gate puppet operations for masterless puppet state (unconfigured)
     '''
-    hookenv.status_set('active',
-                       'Masterless puppet configued')
+    hookenv.status_set('maintenance',
+                       'Configuring puppet repository')
+    p = PuppetConfigs()
+    # Configure puppet repo
+    p.install_puppet_apt_src()
     charms.apt.queue_install(['puppet-common'])
     charms.apt.install_queued()
+    hookenv.status_set('active',
+                       'Masterless puppet configued')
     set_state('puppet.available')
 
 


### PR DESCRIPTION
Packages were being installed in `install_puppet_apt_src()`, but it would be better if that function was only responsible for setting up the repo.  This is especially better in masterless situations when we don't want puppet-agent, etc, etc to be installed.

On the subject of masterless, I noticed we weren't actually configuring the puppet repo in masterless mode.  This PR fixes that oversight.