### PR TITLE
Add description to puppet-gpg-key

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,8 @@ options:
         value in the dpkg database. Valid values are "install" and "hold".
   puppet-gpg-key:
     type: string
+    description: >
+        Puppet gpg id used to configure Puppetlabs apt sources
     default: |
      -----BEGIN PGP PUBLIC KEY BLOCK-----
      Version: GnuPG v1.4.12 (GNU/Linux)


### PR DESCRIPTION
Doing a "charm proof" on charms that use this layer gives this warning: 

`W: config.yaml: option puppet-gpg-key does not have the keys: description`

This PR is to fix this. :)